### PR TITLE
Enable and start kublet service in single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,7 @@ sudo systemctl daemon-reload
 ```
 
 ```
-sudo systemctl enable kubelet
-```
-
-```
-sudo systemctl start kubelet
+sudo systemctl enable --now kubelet
 ```
 
 ### Verification


### PR DESCRIPTION
It saves a `systemctl` command but can be done both ways.